### PR TITLE
Fix typo in OIDC trust relationship setup

### DIFF
--- a/content/cli/authentication.mdx
+++ b/content/cli/authentication.mdx
@@ -43,7 +43,7 @@ To add a trust relationship for GitHub Actions, you can go through the following
 3. Click the Add trust relationship button
 4. Select GitHub as the provider
 5. Enter a GitHub User or Organization for the trust relationship
-6. Enter the full url for the GitHub repository that will build images via Depot
+6. Enter the name of the GitHub repository that will build images via Depot (Note: this is the repository name, not the full URL and it must match the repository name exactly)
 7. Click Add trust relationship
 
 ### Adding a trust relationship for Buildkite


### PR DESCRIPTION
This isn't the full URL anymore and is the repository name exactly as it is on GitHub (i.e. case sensitive).