### PR TITLE
Update docs GHA actions/checkout examples from v3 to v4

### DIFF
--- a/content/integrations/github-actions.mdx
+++ b/content/integrations/github-actions.mdx
@@ -36,7 +36,7 @@ jobs:
       id-token: write
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up Depot CLI
         uses: depot/setup-action@v1
@@ -65,7 +65,7 @@ jobs:
       id-token: write
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up Depot CLI
         uses: depot/setup-action@v1
@@ -88,7 +88,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up Depot CLI
         uses: depot/setup-action@v1
@@ -117,7 +117,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up Depot CLI
         uses: depot/setup-action@v1
@@ -160,7 +160,7 @@ jobs:
       id-token: write
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up Depot CLI
         uses: depot/setup-action@v1
@@ -198,7 +198,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up Depot CLI
         uses: depot/setup-action@v1
@@ -237,7 +237,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up Depot CLI
         uses: depot/setup-action@v1
@@ -282,7 +282,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up Depot CLI
         uses: depot/setup-action@v1
@@ -324,7 +324,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up Depot CLI
         uses: depot/setup-action@v1
@@ -376,7 +376,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up Depot CLI
         uses: depot/setup-action@v1
@@ -418,7 +418,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up Depot CLI
         uses: depot/setup-action@v1


### PR DESCRIPTION
I tested this on a GHA build and checkout v4 worked without changes to anything else in the doc examples.

I also noticed the SBOM example uses: `actions/upload-artifact@v3.1.0`, which is outdated on the same docs page, but I didn't change it in this PR or test it to v4.