### PR TITLE
Update rust-dockerfile.mdx

### DIFF
--- a/content/languages/rust-dockerfile.mdx
+++ b/content/languages/rust-dockerfile.mdx
@@ -16,7 +16,7 @@ WORKDIR /app
 COPY . .
 RUN cargo chef prepare --recipe-path recipe.json
 
-FROM base as builder
+FROM base AS builder
 WORKDIR /app
 COPY --from=planner /app/recipe.json recipe.json
 RUN --mount=type=cache,target=/usr/local/cargo/registry \
@@ -86,7 +86,7 @@ By creating the dependency tree separately from the actual installation of depen
 ### Stage 3: `FROM base as builder`
 
 ```dockerfile
-FROM base as builder
+FROM base AS builder
 WORKDIR /app
 COPY --from=planner /app/recipe.json recipe.json
 RUN --mount=type=cache,target=/usr/local/cargo/registry \


### PR DESCRIPTION
I was getting:

` => WARN: FromAsCasing: 'as' and 'FROM' keywords' casing do not match`

So I uppercased 'AS' keyworkds.