### PR TITLE
Add missing argument to `brew install` command in Fly.io doc

### DIFF
--- a/content/integrations/fly.mdx
+++ b/content/integrations/fly.mdx
@@ -19,7 +19,7 @@ Before you can build and push your container images with Depot to your Fly regis
 With an account and project, all that is left is [installing the Depot CLI](/docs/cli/installation) by running the following command:
 
 ```shell
-brew install # for Mac
+brew install depot/tap/depot # for Mac
 curl -L https://depot.dev/install-cli.sh | sh # for Linux
 ```
 


### PR DESCRIPTION
I was reading [these docs for getting started with Fly.io](https://depot.dev/docs/integrations/fly), and noticed that the instructions under "Getting started with Depot" for macOS were `brew install` instead of `brew install depot/tap/depot`.