### PR TITLE
Revert "Add fly.io to integrations list"

### DIFF
--- a/content/guides/continuous-integration.mdx
+++ b/content/guides/continuous-integration.mdx
@@ -20,7 +20,6 @@ Running `depot` in a continuous integration environment is a great way to get fa
 - [Bitbucket Pipelines](../integrations/bitbucket-pipelines)
 - [Buildkite](../integrations/buildkite)
 - [CircleCI](../integrations/circleci)
-- [Fly.io](../integrations/fly)
 - [GitHub Actions](../integrations/github-actions)
 - [GitLab CI](../integrations/gitlab-ci)
 - [Google Cloud Build](../integrations/google-cloud-build)


### PR DESCRIPTION
Reverts depot/docs#98

@lukevmorris Further investigation reveals that we categorize fly.io as a **DevTool**, rather than a **CI/CD** integration, so I think it was left out of this list for a reason. Whoops! I'm learnin' 😄 