### PR TITLE
chore: update sccache configuration instructions

### DIFF
--- a/content/cache/reference/sccache.mdx
+++ b/content/cache/reference/sccache.mdx
@@ -24,13 +24,15 @@ To manually configure sccache to use Depot Cache, you will need to set two envir
 
 ```shell
 export SCCACHE_WEBDAV_ENDPOINT=https://cache.depot.dev
-export SCCACHE_WEBDAV_PASSWORD=DEPOT_TOKEN
+export SCCACHE_WEBDAV_TOKEN=DEPOT_TOKEN
 ```
 
-If you are a member of multiple organizations, and you are authenticating with a user token, you must additionally specify which organization to use for cache storage as follows:
+If you are a member of multiple organizations, and you are authenticating with a user token, you must specify a password as well as which organization to use for cache storage as follows:
 
 ```shell
+export SCCACHE_WEBDAV_ENDPOINT=https://cache.depot.dev
 export SCCACHE_WEBDAV_USERNAME=DEPOT_ORG_ID
+export SCCACHE_WEBDAV_PASSWORD=DEPOT_TOKEN
 ```
 
 ## Using Depot Cache with sccache

--- a/content/cache/reference/sccache.mdx
+++ b/content/cache/reference/sccache.mdx
@@ -27,7 +27,7 @@ export SCCACHE_WEBDAV_ENDPOINT=https://cache.depot.dev
 export SCCACHE_WEBDAV_TOKEN=DEPOT_TOKEN
 ```
 
-If you are a member of multiple organizations, and you are authenticating with a user token, you must specify a password as well as which organization to use for cache storage as follows:
+If you are a member of multiple organizations, and you are authenticating with a user token, you must instead specify a password along with which organization should be used for cache storage as follows:
 
 ```shell
 export SCCACHE_WEBDAV_ENDPOINT=https://cache.depot.dev


### PR DESCRIPTION
The current instructions for connecting sccache to cache.depot.dev result in an authentication error. sccache requires the presence of both a username and password before attaching basic auth headers. For the default case, a token will suffice instead.