### PR TITLE
Update Mint to RWX

### DIFF
--- a/content/cli/authentication.mdx
+++ b/content/cli/authentication.mdx
@@ -28,7 +28,7 @@ To generate a project token, you can go through the following steps:
 
 ## OIDC trust relationships
 
-If you use GitHub Actions, CircleCI, or Buildkite as your CI provider, we can directly integrate with [GitHub Actions OIDC](https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/about-security-hardening-with-openid-connect), [CircleCI OIDC](https://circleci.com/docs/openid-connect-tokens/), [Buildkite OIDC](https://buildkite.com/docs/agent/v3/cli-oidc), or [Mint](https://www.rwx.com/mint) via trust relationships. This token exchange is a great way to plug Depot into your existing Actions workflows, CircleCI jobs, or Buildkite pipelines, as it requires no static secrets, and credentials are short-lived.
+If you use GitHub Actions, CircleCI, or Buildkite as your CI provider, we can directly integrate with [GitHub Actions OIDC](https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/about-security-hardening-with-openid-connect), [CircleCI OIDC](https://circleci.com/docs/openid-connect-tokens/), [Buildkite OIDC](https://buildkite.com/docs/agent/v3/cli-oidc), or [RWX](https://www.rwx.com/) via trust relationships. This token exchange is a great way to plug Depot into your existing Actions workflows, CircleCI jobs, or Buildkite pipelines, as it requires no static secrets, and credentials are short-lived.
 
 You configure a trust relationship in Depot that allows your GitHub Actions workflows, CircleCI jobs, or Buildkite pipelines to access your project via a token exchange. The CI job requests an access token from Depot, and we check the request details to see if they match a configured trust relationship for your project. If everything matches, we generate a temporary access token and return it to the job. This temporary access token is only valid for the duration of the job that requested it.
 
@@ -71,13 +71,13 @@ To add a trust relationship for Buildkite, you can go through the following step
 6. Enter the pipeline organization slug (i.e., `buildkite.com/<org-slug>/<pipeline-slug>`)
 7. Click Add trust relationship
 
-### Adding a trust relationship for Mint
+### Adding a trust relationship for RWX
 
-To add a trust relationship for Mint, you can go through the following steps:
+To add a trust relationship for RWX, you can go through the following steps:
 
 1. Open your Project Details page by clicking on a project from your projects list
 2. Click the Settings button next to your project ID
 3. Click the Add trust relationship button
-4. Select Mint as the provider
-5. Enter your Mint Vault subject you configured [here](https://www.rwx.com/docs/mint/oidc-depot#configure-depot-in-mint)
+4. Select RWX as the provider
+5. Enter your RWX Vault subject you configured [here](https://www.rwx.com/docs/mint/oidc-depot#configure-depot-in-rwx)
 6. Click Add trust relationship

--- a/content/container-builds/overview.mdx
+++ b/content/container-builds/overview.mdx
@@ -57,7 +57,7 @@ We have extensive integrations with most major CI providers and developer tools 
 
 #### OIDC support
 
-We support OIDC trust relationships with GitHub, CircleCI, Buildkite, and Mint so that you don't need any static access tokens in your CI provider to leverage Depot. You can learn more about configuring a trust relationship in our [authentication docs.](/docs/cli/authentication)
+We support OIDC trust relationships with GitHub, CircleCI, Buildkite, and RWX so that you don't need any static access tokens in your CI provider to leverage Depot. You can learn more about configuring a trust relationship in our [authentication docs.](/docs/cli/authentication)
 
 ### Integrate with your existing dev tools
 


### PR DESCRIPTION
Updates existing Mint documentation to be branded as RWX. Read more here https://www.rwx.com/blog/mint-to-rwx

Thanks as always depot friends!