### PR TITLE
Add `packages` to supported CI permissions

### DIFF
--- a/content/ci/compatibility.mdx
+++ b/content/ci/compatibility.mdx
@@ -183,4 +183,4 @@ Only Depot `runs-on` labels are supported. Any label that Depot doesn't recogniz
 
 ### Permissions
 
-The following permissions are supported: `actions`, `checks`, `contents`, `id-token`, `metadata`, `pull_requests`, `statuses`, `workflows`.
+The following permissions are supported: `actions`, `checks`, `contents`, `id-token`, `metadata`, `packages`, `pull_requests`, `statuses`, `workflows`.


### PR DESCRIPTION
## Summary
- Adds `packages` to the list of supported workflow permissions on the CI compatibility page

Closes DEP-3907

## Test plan
- [ ] Verify docs build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)