### PR TITLE
docs(ci): document dispatch, cancel, rerun, retry CLI verbs

### DIFF
--- a/content/ci/how-to-guides/manage-workflow-runs.mdx
+++ b/content/ci/how-to-guides/manage-workflow-runs.mdx
@@ -8,7 +8,7 @@ You can trigger, check status, retry, rerun, and cancel workflow runs from the D
 
 ## Trigger a workflow on demand
 
-### CLI
+### CLI: run against your working tree
 
 Run any workflow on demand with `depot ci run`:
 
@@ -24,6 +24,19 @@ When you run `depot ci run` with uncommitted changes in your working tree, the C
 
 Each time you run `depot ci run` locally, the CLI uploads a fresh patch, so you can keep iterating until the workflow passes.
 
+### CLI: dispatch a `workflow_dispatch` workflow
+
+Trigger a workflow that declares an `on.workflow_dispatch` trigger with `depot ci dispatch`. Inputs are validated against the workflow's declared input schema.
+
+```shell
+depot ci dispatch --repo depot/cli --workflow deploy.yml --ref main \
+  --input environment=staging --input dry_run=true
+```
+
+> `--workflow` takes the workflow file's **basename** (e.g. `deploy.yml`), not the full `.depot/workflows/deploy.yml` path. This matches GitHub's `workflow_dispatch` API convention.
+
+The command returns the new `run_id`. Use `--output json` to consume the response programmatically. See [`depot ci dispatch`](/docs/cli/reference/depot-ci#depot-ci-dispatch) for the full flag list.
+
 ### Dashboard
 
 You can start workflows with an `on.workflow_dispatch` trigger from the Depot dashboard.
@@ -37,7 +50,25 @@ If you don't specify a branch or tag, the workflow runs against the repository's
 
 ## Retry a failed job
 
-You can retry an individual failed or cancelled job without rerunning the entire workflow.
+You can retry an individual failed or cancelled job, or every failed/cancelled job in a workflow, without rerunning the successful jobs.
+
+### CLI
+
+Retry a single job:
+
+```shell
+depot ci retry <run-id> --job <job-id>
+```
+
+Retry every failed/cancelled job in the workflow:
+
+```shell
+depot ci retry <run-id> --failed
+```
+
+Each retry creates a new attempt; previous attempts are preserved and visible in `depot ci status`. See [`depot ci retry`](/docs/cli/reference/depot-ci#depot-ci-retry) for details.
+
+### Dashboard
 
 1. Go to [Depot CI](https://depot.dev/orgs/_/workflows) and click on the workflow.
 2. Click **Retry job** for the job you want to retry.
@@ -46,7 +77,17 @@ Depot creates a new attempt for that job and queues it immediately. The rest of 
 
 ## Rerun a workflow
 
-After a workflow finishes, you can rerun the whole workflow or only the failed and cancelled jobs.
+After a workflow finishes, you can rerun every job in the workflow from scratch, or retry only the failed/cancelled jobs (see [Retry a failed job](#retry-a-failed-job)).
+
+### CLI
+
+```shell
+depot ci rerun <run-id>
+```
+
+For multi-workflow runs, pass `--workflow <id>` to select which workflow to rerun. A workflow must be in a terminal state (finished, failed, or cancelled) before it can be rerun — cancel it first if it's still running. See [`depot ci rerun`](/docs/cli/reference/depot-ci#depot-ci-rerun) for details.
+
+### Dashboard
 
 1. Go to [Depot CI](https://depot.dev/orgs/_/workflows) and click on the workflow.
 2. Do one of the following:
@@ -56,6 +97,24 @@ After a workflow finishes, you can rerun the whole workflow or only the failed a
 ## Cancel a workflow
 
 You can cancel a workflow or an individual job while it's queued or running.
+
+### CLI
+
+Cancel an entire workflow (all jobs within it):
+
+```shell
+depot ci cancel <run-id> --workflow <workflow-id>
+```
+
+Cancel a single job (the containing workflow is resolved automatically from the run's status):
+
+```shell
+depot ci cancel <run-id> --job <job-id>
+```
+
+See [`depot ci cancel`](/docs/cli/reference/depot-ci#depot-ci-cancel) for details.
+
+### Dashboard
 
 1. Go to [Depot CI](https://depot.dev/orgs/_/workflows) and click on the workflow.
 2. Do one of the following:

--- a/content/cli/reference/depot-ci.mdx
+++ b/content/cli/reference/depot-ci.mdx
@@ -1,7 +1,7 @@
 ---
 title: 'Depot CLI: Depot CI commands reference'
 ogTitle: 'Depot CLI: Depot CI commands reference'
-description: Reference for all Depot CI CLI commands, including migrate, run, ssh, secrets, vars, status, and logs.
+description: Reference for all Depot CI CLI commands, including migrate, run, dispatch, status, cancel, rerun, retry, logs, ssh, secrets, and vars.
 ---
 
 Reference for all `depot ci` commands. To install the Depot CLI, see [Installation](/docs/cli/installation).
@@ -231,6 +231,196 @@ Replace `<run-id>` with the run ID returned by `depot ci run` or visible in the 
 | ----------------- | -------------------------------------------------------------------------- |
 | `--org <id>`      | Organization ID (required when user is a member of multiple organizations) |
 | `--token <token>` | Depot API token                                                            |
+
+---
+
+## `depot ci dispatch`
+
+Triggers a workflow via `workflow_dispatch`. Inputs are validated against the workflow's declared input schema, so required inputs must be supplied and typed inputs (`boolean`, `number`, `choice`) are coerced on the server.
+
+```bash
+depot ci dispatch --repo <owner/repo> --workflow <filename> --ref <branch-or-tag>
+```
+
+> **Note:** `--workflow` takes the **workflow file's basename** (e.g. `deploy.yml`), not the full repo path `.depot/workflows/deploy.yml`. This matches GitHub's `workflow_dispatch` API convention.
+
+### Flags
+
+| Flag                     | Description                                                                      |
+| ------------------------ | -------------------------------------------------------------------------------- |
+| `--repo <owner/repo>`    | Target GitHub repository (required)                                              |
+| `--workflow <filename>`  | Workflow file basename, e.g. `deploy.yml` — NOT the full path (required)         |
+| `--ref <branch-or-tag>`  | Branch or tag name to run the workflow on (required)                             |
+| `--input <key>=<value>`  | Workflow input as `key=value`; repeat for multiple inputs                        |
+| `--output json`          | Output the RPC response as JSON                                                  |
+| `--org <id>`             | Organization ID (required when user is a member of multiple organizations)       |
+| `--token <token>`        | Depot API token                                                                  |
+
+### Examples
+
+```bash
+# Dispatch a workflow on the main branch
+depot ci dispatch --repo depot/cli --workflow deploy.yml --ref main
+
+# Pass inputs (repeatable)
+depot ci dispatch --repo depot/cli --workflow deploy.yml --ref main \
+  --input environment=staging --input dry_run=true
+
+# Output the RPC response as JSON
+depot ci dispatch --repo depot/cli --workflow deploy.yml --ref main --output json
+```
+
+The JSON response contains the created run ID:
+
+```json
+{
+  "org_id": "<org-id>",
+  "run_id": "<run-id>"
+}
+```
+
+---
+
+## `depot ci cancel`
+
+Cancels a queued or running workflow (all its jobs), or a single job within a workflow.
+
+```bash
+depot ci cancel <run-id> --workflow <workflow-id>
+depot ci cancel <run-id> --job <job-id>
+```
+
+Exactly one of `--workflow` or `--job` must be provided; they are mutually exclusive. When you pass `--job`, the CLI looks up the containing workflow via the run's status, so you do not need to also pass `--workflow`.
+
+Workflows and jobs that have already reached a terminal state (finished, failed, or cancelled) cannot be cancelled and will return an error.
+
+### Flags
+
+| Flag                      | Description                                                                |
+| ------------------------- | -------------------------------------------------------------------------- |
+| `--workflow <id>`         | Workflow ID to cancel (mutually exclusive with `--job`)                    |
+| `--job <id>`              | Job ID to cancel (mutually exclusive with `--workflow`)                    |
+| `--output json`           | Output the RPC response as JSON                                            |
+| `--org <id>`              | Organization ID (required when user is a member of multiple organizations) |
+| `--token <token>`         | Depot API token                                                            |
+
+### Examples
+
+```bash
+# Cancel an entire workflow (all jobs within it)
+depot ci cancel <run-id> --workflow <workflow-id>
+
+# Cancel a single job (workflow is resolved automatically)
+depot ci cancel <run-id> --job <job-id>
+
+# Output the response as JSON
+depot ci cancel <run-id> --workflow <workflow-id> --output json
+```
+
+JSON responses:
+
+```json
+# --workflow
+{ "workflow_id": "<workflow-id>", "status": "cancelled" }
+
+# --job
+{ "job_id": "<job-id>", "status": "cancelled" }
+```
+
+---
+
+## `depot ci rerun`
+
+Re-runs every job in a workflow that has reached a terminal state. Creates a new attempt for each job.
+
+```bash
+depot ci rerun <run-id>
+```
+
+If the run contains multiple workflows, pass `--workflow <id>` to select one. When the run contains a single workflow, the CLI resolves it automatically. Rerunning a workflow that is still running returns a precondition error — cancel it first if you want to restart.
+
+### Flags
+
+| Flag                     | Description                                                                      |
+| ------------------------ | -------------------------------------------------------------------------------- |
+| `--workflow <id>`        | Workflow ID to rerun (required when the run contains multiple workflows)         |
+| `--output json`          | Output the RPC response as JSON                                                  |
+| `--org <id>`             | Organization ID (required when user is a member of multiple organizations)       |
+| `--token <token>`        | Depot API token                                                                  |
+
+### Examples
+
+```bash
+# Rerun the (single) workflow in a run
+depot ci rerun <run-id>
+
+# Rerun a specific workflow in a multi-workflow run
+depot ci rerun <run-id> --workflow <workflow-id>
+
+# Output the response as JSON
+depot ci rerun <run-id> --output json
+```
+
+JSON response:
+
+```json
+{ "workflow_id": "<workflow-id>", "job_count": 5 }
+```
+
+---
+
+## `depot ci retry`
+
+Retries a single failed or cancelled job, or every failed/cancelled job in a workflow.
+
+```bash
+depot ci retry <run-id> --job <job-id>
+depot ci retry <run-id> --failed
+```
+
+Exactly one of `--job` or `--failed` must be provided; they are mutually exclusive.
+
+- `--job <id>` retries a single job. The workflow containing the job is resolved automatically from the run's status.
+- `--failed` retries every failed/cancelled job in the workflow. If the run contains multiple workflows, pass `--workflow <id>`; otherwise the single workflow is resolved automatically.
+
+Each retry creates a new attempt for the selected job(s); the previous attempts are preserved and visible in `depot ci status`.
+
+### Flags
+
+| Flag                     | Description                                                                      |
+| ------------------------ | -------------------------------------------------------------------------------- |
+| `--job <id>`             | Job ID to retry (mutually exclusive with `--failed`)                             |
+| `--failed`               | Retry every failed/cancelled job in the workflow (mutually exclusive with `--job`) |
+| `--workflow <id>`        | Workflow ID; required with `--failed` when the run has multiple workflows        |
+| `--output json`          | Output the RPC response as JSON                                                  |
+| `--org <id>`             | Organization ID (required when user is a member of multiple organizations)       |
+| `--token <token>`        | Depot API token                                                                  |
+
+### Examples
+
+```bash
+# Retry a single job
+depot ci retry <run-id> --job <job-id>
+
+# Retry every failed/cancelled job in the (single) workflow
+depot ci retry <run-id> --failed
+
+# Retry every failed/cancelled job in a specific workflow
+depot ci retry <run-id> --failed --workflow <workflow-id>
+
+# Output the response as JSON
+depot ci retry <run-id> --job <job-id> --output json
+```
+
+JSON responses:
+
+```json
+# --job
+{ "job_id": "<job-id>", "attempt": 2, "status": "queued" }
+
+# --failed
+{ "workflow_id": "<workflow-id>", "job_ids": ["<job-id>", "..."], "job_count": 3 }
+```
 
 ---
 

--- a/content/cli/reference/depot-ci.mdx
+++ b/content/cli/reference/depot-ci.mdx
@@ -246,15 +246,15 @@ depot ci dispatch --repo <owner/repo> --workflow <filename> --ref <branch-or-tag
 
 ### Flags
 
-| Flag                     | Description                                                                      |
-| ------------------------ | -------------------------------------------------------------------------------- |
-| `--repo <owner/repo>`    | Target GitHub repository (required)                                              |
-| `--workflow <filename>`  | Workflow file basename, e.g. `deploy.yml` — NOT the full path (required)         |
-| `--ref <branch-or-tag>`  | Branch or tag name to run the workflow on (required)                             |
-| `--input <key>=<value>`  | Workflow input as `key=value`; repeat for multiple inputs                        |
-| `--output json`          | Output the RPC response as JSON                                                  |
-| `--org <id>`             | Organization ID (required when user is a member of multiple organizations)       |
-| `--token <token>`        | Depot API token                                                                  |
+| Flag                    | Description                                                                |
+| ----------------------- | -------------------------------------------------------------------------- |
+| `--repo <owner/repo>`   | Target GitHub repository (required)                                        |
+| `--workflow <filename>` | Workflow file basename, e.g. `deploy.yml` — NOT the full path (required)   |
+| `--ref <branch-or-tag>` | Branch or tag name to run the workflow on (required)                       |
+| `--input <key>=<value>` | Workflow input as `key=value`; repeat for multiple inputs                  |
+| `--output json`         | Output the RPC response as JSON                                            |
+| `--org <id>`            | Organization ID (required when user is a member of multiple organizations) |
+| `--token <token>`       | Depot API token                                                            |
 
 ### Examples
 
@@ -296,13 +296,13 @@ Workflows and jobs that have already reached a terminal state (finished, failed,
 
 ### Flags
 
-| Flag                      | Description                                                                |
-| ------------------------- | -------------------------------------------------------------------------- |
-| `--workflow <id>`         | Workflow ID to cancel (mutually exclusive with `--job`)                    |
-| `--job <id>`              | Job ID to cancel (mutually exclusive with `--workflow`)                    |
-| `--output json`           | Output the RPC response as JSON                                            |
-| `--org <id>`              | Organization ID (required when user is a member of multiple organizations) |
-| `--token <token>`         | Depot API token                                                            |
+| Flag              | Description                                                                |
+| ----------------- | -------------------------------------------------------------------------- |
+| `--workflow <id>` | Workflow ID to cancel (mutually exclusive with `--job`)                    |
+| `--job <id>`      | Job ID to cancel (mutually exclusive with `--workflow`)                    |
+| `--output json`   | Output the RPC response as JSON                                            |
+| `--org <id>`      | Organization ID (required when user is a member of multiple organizations) |
+| `--token <token>` | Depot API token                                                            |
 
 ### Examples
 
@@ -341,12 +341,12 @@ If the run contains multiple workflows, pass `--workflow <id>` to select one. Wh
 
 ### Flags
 
-| Flag                     | Description                                                                      |
-| ------------------------ | -------------------------------------------------------------------------------- |
-| `--workflow <id>`        | Workflow ID to rerun (required when the run contains multiple workflows)         |
-| `--output json`          | Output the RPC response as JSON                                                  |
-| `--org <id>`             | Organization ID (required when user is a member of multiple organizations)       |
-| `--token <token>`        | Depot API token                                                                  |
+| Flag              | Description                                                                |
+| ----------------- | -------------------------------------------------------------------------- |
+| `--workflow <id>` | Workflow ID to rerun (required when the run contains multiple workflows)   |
+| `--output json`   | Output the RPC response as JSON                                            |
+| `--org <id>`      | Organization ID (required when user is a member of multiple organizations) |
+| `--token <token>` | Depot API token                                                            |
 
 ### Examples
 
@@ -364,7 +364,7 @@ depot ci rerun <run-id> --output json
 JSON response:
 
 ```json
-{ "workflow_id": "<workflow-id>", "job_count": 5 }
+{"workflow_id": "<workflow-id>", "job_count": 5}
 ```
 
 ---
@@ -387,14 +387,14 @@ Each retry creates a new attempt for the selected job(s); the previous attempts 
 
 ### Flags
 
-| Flag                     | Description                                                                      |
-| ------------------------ | -------------------------------------------------------------------------------- |
-| `--job <id>`             | Job ID to retry (mutually exclusive with `--failed`)                             |
-| `--failed`               | Retry every failed/cancelled job in the workflow (mutually exclusive with `--job`) |
-| `--workflow <id>`        | Workflow ID; required with `--failed` when the run has multiple workflows        |
-| `--output json`          | Output the RPC response as JSON                                                  |
-| `--org <id>`             | Organization ID (required when user is a member of multiple organizations)       |
-| `--token <token>`        | Depot API token                                                                  |
+| Flag              | Description                                                                        |
+| ----------------- | ---------------------------------------------------------------------------------- |
+| `--job <id>`      | Job ID to retry (mutually exclusive with `--failed`)                               |
+| `--failed`        | Retry every failed/cancelled job in the workflow (mutually exclusive with `--job`) |
+| `--workflow <id>` | Workflow ID; required with `--failed` when the run has multiple workflows          |
+| `--output json`   | Output the RPC response as JSON                                                    |
+| `--org <id>`      | Organization ID (required when user is a member of multiple organizations)         |
+| `--token <token>` | Depot API token                                                                    |
 
 ### Examples
 


### PR DESCRIPTION
## Summary

The CLI just grew four new verbs over in [depot/cli#486](https://github.com/depot/cli/pull/486). The docs didn't know about them yet. This PR fixes that.

## What was happening

`depot ci` previously documented `migrate`, `run`, `status`, `logs`, `ssh`, `secrets`, and `vars` — a read-only/configuration surface. The CLI could tell you everything about a run, but nothing about how to *do* anything about it from the terminal. The how-to for managing workflow runs had parallel "CLI" and "Dashboard" subsections under "Trigger", but the Retry / Rerun / Cancel tasks were dashboard-only — leaving terminal-first users to click around.

## What happens now

**`docs/cli/reference/depot-ci.mdx`** gets four new reference sections between `status` and `logs`, each following the existing shape (prose + flag table + examples + JSON response shape):

- `depot ci dispatch` — `--repo --workflow --ref --input k=v`, with a prominent callout that `--workflow` wants the file's **basename** (`deploy.yml`), not `.depot/workflows/deploy.yml`. Matches GitHub's `workflow_dispatch` API convention.
- `depot ci cancel` — both the `--workflow` and `--job` paths, with the auto-resolve-workflow-from-job behavior documented.
- `depot ci rerun` — auto-resolve for single-workflow runs, and the "workflow must be terminal" precondition.
- `depot ci retry` — both `--job` and `--failed`, with the `--workflow` rule for multi-workflow runs under `--failed`.

**`docs/ci/how-to-guides/manage-workflow-runs.mdx`** gains symmetric `### CLI` subsections under **Retry a failed job**, **Rerun a workflow**, and **Cancel a workflow**, each linking back to the reference anchor. Under **Trigger a workflow on demand**, a new `### CLI: dispatch a workflow_dispatch workflow` subsection sits next to the existing `depot ci run` CLI flow — so the whole page now has a consistent CLI/Dashboard split for every task.

The page's description frontmatter is updated to list the new verbs so they surface in search.

## Anything else?

Nothing touched outside those two files — `ideation/`, `plans/`, `content/api/versioning.mdx`, and `.DS_Store` were all untracked but unrelated, so they're deliberately left alone.

Refs: DEP-4221
Pairs with: depot/cli#486

Made with [Cursor](https://cursor.com)